### PR TITLE
[treadmill] Add number of calibration/warm-up requests as parameters

### DIFF
--- a/ContinuousStatistic.h
+++ b/ContinuousStatistic.h
@@ -17,15 +17,14 @@
 #include "treadmill/Histogram.h"
 #include "treadmill/Statistic.h"
 
+DECLARE_int32(default_calibration_samples);
+DECLARE_int32(default_warmup_samples);
+
 namespace facebook {
 namespace windtunnel {
 namespace treadmill {
 
 const int kNumberOfBins = 1024;
-
-const int kCalibrationSamples = 10;
-
-const int kWarmupSamples = 10;
 
 const int kExceptionalValues = 1000;
 
@@ -78,7 +77,9 @@ class ContinuousStatistic : public Statistic {
   }
 
   explicit ContinuousStatistic(const std::string& name) :
-    ContinuousStatistic(name, kWarmupSamples, kCalibrationSamples) {}
+    ContinuousStatistic(name,
+                        FLAGS_default_warmup_samples,
+                        FLAGS_default_calibration_samples) {}
 
   std::unique_ptr<Statistic> clone() const override {
     return std::unique_ptr<Statistic>(new ContinuousStatistic(*this));

--- a/StatisticsManager.cpp
+++ b/StatisticsManager.cpp
@@ -62,7 +62,8 @@ ContinuousStatistic& StatisticsManager::getContinuousStat(
     if (name == REQUEST_LATENCY) {
       // More warmup and calibration samples for request latency
       it = stat_map_.emplace(name, folly::make_unique<ContinuousStatistic>(
-        name, 1000, 1000)).first;
+        name, FLAGS_latency_warmup_samples, FLAGS_latency_calibration_samples)
+      ).first;
     } else {
       it = stat_map_.emplace(name, folly::make_unique<ContinuousStatistic>(
         name)).first;

--- a/StatisticsManager.h
+++ b/StatisticsManager.h
@@ -17,6 +17,9 @@
 #include "treadmill/CounterStatistic.h"
 #include "treadmill/Statistic.h"
 
+DECLARE_int32(latency_calibration_samples);
+DECLARE_int32(latency_warmup_samples);
+
 namespace facebook {
 namespace windtunnel {
 namespace treadmill {

--- a/Treadmill.cpp
+++ b/Treadmill.cpp
@@ -61,25 +61,50 @@ DEFINE_int32(runtime,
              120,
              "The total runtime in seconds.");
 
+// The file to store the JSON output statistics
 DEFINE_string(output_file,
               "",
               "Where to print the json output of statistics.");
 
+// The max number of requests to have outstanding per worker
 DEFINE_int32(max_outstanding_requests,
              1000,
              "The max number of requests to have outstanding per worker.");
 
+// Config filename to pass into the workload in JSON format
 DEFINE_string(config_in_file,
               "",
               "Config filename to pass into the workload in JSON format.");
 
+// Config filename to export from the workload in JSON format
 DEFINE_string(config_out_file,
               "",
               "Config filename to export from the workload in JSON format.");
 
+// Comma-separated list of CPU IDs to pin the workers
 DEFINE_string(cpu_affinity,
               "",
               "Comma-separated list of CPU IDs to pin the workers.");
+
+// Default number of calibration samples for continuous statistics
+DEFINE_int32(default_calibration_samples,
+             10,
+             "Default number of calibration samples for continuous statistics.");
+
+// Default number of warm-up samples for continuous statistics
+DEFINE_int32(default_warmup_samples,
+             10,
+             "Default number of warm-up samples for continuous statistics.");
+
+// Number of calibration samples for latency statistics
+DEFINE_int32(latency_calibration_samples,
+             1000,
+             "Number of calibration samples for latency statistics.");
+
+// Number of warm-up samples for latency statistics
+DEFINE_int32(latency_warmup_samples,
+             1000,
+             "Number of warm-up samples for latency statistics.");
 
 namespace facebook {
 namespace windtunnel {

--- a/Treadmill.h
+++ b/Treadmill.h
@@ -49,15 +49,32 @@ DECLARE_int32(request_per_second);
 // The total testing time in second
 DECLARE_int32(runtime);
 
+// The file to store the JSON output statistics
 DECLARE_string(output_file);
 
+// The max number of requests to have outstanding per worker
 DECLARE_int32(max_outstanding_requests);
 
+// Config filename to pass into the workload in JSON format
 DECLARE_string(config_in_file);
 
+// Config filename to export from the workload in JSON format
 DECLARE_string(config_out_file);
 
+// Comma-separated list of CPU IDs to pin the workers
 DECLARE_string(cpu_affinity);
+
+// Default number of calibration samples for continuous statistics
+DECLARE_int32(default_calibration_samples);
+
+// Default number of warm-up samples for continuous statistics
+DECLARE_int32(default_warmup_samples);
+
+// Number of calibration samples for latency statistics
+DECLARE_int32(latency_calibration_samples);
+
+// Number of warm-up samples for latency statistics
+DECLARE_int32(latency_warmup_samples);
 
 namespace facebook {
 namespace windtunnel {


### PR DESCRIPTION
- Add number of calibration/warm-up requests are parameters
- This shouldn't change the original behavior of the program as the default values are kept the same