### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
-## Code of Conduct
+### Code of Conduct
 
 The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,10 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ### Pull Requests
 
 We actively welcome your pull requests.


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [treadmill community profile checklist](https://github.com/facebook/treadmill/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
<img width="1008" alt="screen shot 2017-12-13 at 7 10 46 am" src="https://user-images.githubusercontent.com/1114467/33945843-fb52ebc8-dfd4-11e7-9d82-c15eacccc129.png">
<img width="1009" alt="screen shot 2017-12-13 at 7 10 54 am" src="https://user-images.githubusercontent.com/1114467/33945844-fb86c786-dfd4-11e7-9f0f-262741e2de9d.png">

issue:
internal task t23481323